### PR TITLE
Fixed import of Onvif module on onvif.ts

### DIFF
--- a/src/app/api/onvif.ts
+++ b/src/app/api/onvif.ts
@@ -1,5 +1,5 @@
 import { CameraConfig } from "@/components/camera-list";
-import { Onvif } from 'onvif/src';
+import { Onvif } from 'onvif';
 
 const cameras = new Map();
 


### PR DESCRIPTION
When trying to run on macOS Sequoia (Apple Silicon) or Windows 11, an error occurred because the Onvif module could not be found in the path provided in line 2 of the file "src/app/api/onvif.ts" the path was "onvif/src". Fixed by using just the module name and it worked correctly in both environments.